### PR TITLE
[react-todo-list step2] 심혁 미션 제출합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
+        "react-virtualized": "^9.22.6",
         "styled-components": "^6.3.6"
       },
       "devDependencies": {
@@ -273,6 +274,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1591,6 +1601,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1776,6 +1795,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3194,7 +3223,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3432,7 +3460,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3503,8 +3530,13 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -3513,6 +3545,24 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-virtualized": {
+      "version": "9.22.6",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
+      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
+    "react-virtualized": "^9.22.6",
     "styled-components": "^6.3.6"
   },
   "devDependencies": {

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,20 +1,45 @@
 import styled from "styled-components";
+import React from "react";
+import { AutoSizer, List } from "react-virtualized";
 import TodoListItem from "./TodoListItem";
 
-export default function TodoList({ todos, removeTodo, toggleTodoChecked }) {
-  return (
-    <Container>
-      {todos.map((todo) => (
+export default React.memo(function TodoList({
+  todos,
+  removeTodo,
+  toggleTodoChecked,
+}) {
+  const rowHeight = 59;
+
+  const rowRenderer = ({ index, key, style }) => {
+    const todo = todos[index];
+    return (
+      <div key={key} style={style}>
         <TodoListItem
-          key={todo.id}
           todo={todo}
           removeTodo={removeTodo}
           toggleTodoChecked={toggleTodoChecked}
         />
-      ))}
+      </div>
+    );
+  };
+
+  return (
+    <Container>
+      <AutoSizer>
+        {({ width, height }) => (
+          <List
+            width={width}
+            height={height}
+            rowCount={todos.length}
+            rowHeight={rowHeight}
+            rowRenderer={rowRenderer}
+            overscanRowCount={5}
+          />
+        )}
+      </AutoSizer>
     </Container>
   );
-}
+});
 
 const Container = styled.div`
   min-height: 320px;

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import React from "react";
+import React, { useCallback } from "react";
 import { AutoSizer, List } from "react-virtualized";
 import TodoListItem from "./TodoListItem";
 
@@ -10,18 +10,21 @@ export default React.memo(function TodoList({
 }) {
   const rowHeight = 59;
 
-  const rowRenderer = ({ index, key, style }) => {
-    const todo = todos[index];
-    return (
-      <div key={key} style={style}>
-        <TodoListItem
-          todo={todo}
-          removeTodo={removeTodo}
-          toggleTodoChecked={toggleTodoChecked}
-        />
-      </div>
-    );
-  };
+  const rowRenderer = useCallback(
+    ({ index, key, style }) => {
+      const todo = todos[index];
+      return (
+        <div key={key} style={style}>
+          <TodoListItem
+            todo={todo}
+            removeTodo={removeTodo}
+            toggleTodoChecked={toggleTodoChecked}
+          />
+        </div>
+      );
+    },
+    [todos, removeTodo, toggleTodoChecked],
+  );
 
   return (
     <Container>

--- a/src/components/TodoListItem.jsx
+++ b/src/components/TodoListItem.jsx
@@ -11,13 +11,8 @@ export default React.memo(function TodoListItem({
   removeTodo,
   toggleTodoChecked,
 }) {
-  const handleToggle = useCallback(() => {
-    toggleTodoChecked(todo.id);
-  }, [todo.id, toggleTodoChecked]);
-
-  const handleRemove = useCallback(() => {
-    removeTodo(todo.id);
-  }, [todo.id, removeTodo]);
+  const handleToggle = () => toggleTodoChecked(todo.id);
+  const handleRemove = () => removeTodo(todo.id);
 
   return (
     <Item>

--- a/src/components/TodoListItem.jsx
+++ b/src/components/TodoListItem.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import React, { useCallback } from "react";
+import React from "react";
 import {
   MdCheckBoxOutlineBlank,
   MdCheckBox,

--- a/src/components/TodoListItem.jsx
+++ b/src/components/TodoListItem.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import React from "react";
+import React, { useCallback } from "react";
 import {
   MdCheckBoxOutlineBlank,
   MdCheckBox,
@@ -11,11 +11,19 @@ export default React.memo(function TodoListItem({
   removeTodo,
   toggleTodoChecked,
 }) {
+  const handleToggle = useCallback(() => {
+    toggleTodoChecked(todo.id);
+  }, [todo.id, toggleTodoChecked]);
+
+  const handleRemove = useCallback(() => {
+    removeTodo(todo.id);
+  }, [todo.id, removeTodo]);
+
   return (
     <Item>
       <CheckboxAndText>
         <CheckButton
-          onClick={() => toggleTodoChecked(todo.id)}
+          onClick={handleToggle}
           role="checkbox"
           aria-checked={todo.checked}
           aria-label={todo.checked ? "할 일 체크 해제" : "할 일 체크"}
@@ -31,12 +39,7 @@ export default React.memo(function TodoListItem({
           {todo.text}
         </TodoText>
       </CheckboxAndText>
-      <RemoveButton
-        onClick={() => {
-          removeTodo(todo.id);
-        }}
-        aria-label="할 일 삭제"
-      >
+      <RemoveButton onClick={handleRemove} aria-label="할 일 삭제">
         <MdRemoveCircleOutline size="24" />
       </RemoveButton>
     </Item>

--- a/src/components/TodoListItem.jsx
+++ b/src/components/TodoListItem.jsx
@@ -1,11 +1,16 @@
 import styled from "styled-components";
+import React from "react";
 import {
   MdCheckBoxOutlineBlank,
   MdCheckBox,
   MdRemoveCircleOutline,
 } from "react-icons/md";
 
-export default function TodoListItem({ todo, removeTodo, toggleTodoChecked }) {
+export default React.memo(function TodoListItem({
+  todo,
+  removeTodo,
+  toggleTodoChecked,
+}) {
   return (
     <Item>
       <CheckboxAndText>
@@ -36,7 +41,7 @@ export default function TodoListItem({ todo, removeTodo, toggleTodoChecked }) {
       </RemoveButton>
     </Item>
   );
-}
+});
 
 const Item = styled.div`
   display: flex;

--- a/src/hooks/useTodos.jsx
+++ b/src/hooks/useTodos.jsx
@@ -1,27 +1,40 @@
-import { useState } from "react";
-export function useTodos() {
-  const [todos, setTodos] = useState([]);
+import { useCallback, useState } from "react";
 
-  const addTodo = (text) => {
+function createBulkTodos() {
+  const array = [];
+  for (let i = 1; i < 2500; i++) {
+    array.push({
+      id: i,
+      text: `할 일${i}`,
+      checked: false,
+    });
+  }
+  return array;
+}
+
+export function useTodos() {
+  const [todos, setTodos] = useState(() => createBulkTodos());
+
+  const addTodo = useCallback((text) => {
     const newTodo = {
       id: Date.now(),
       text,
       checked: false,
     };
     setTodos((prev) => [...prev, newTodo]);
-  };
+  }, []);
 
-  const removeTodo = (id) => {
+  const removeTodo = useCallback((id) => {
     setTodos((prev) => prev.filter((todo) => todo.id !== id));
-  };
+  }, []);
 
-  const toggleTodoChecked = (id) => {
+  const toggleTodoChecked = useCallback((id) => {
     setTodos((prev) =>
       prev.map((todo) =>
-        todo.id === id ? { ...todo, checked: !todo.checked } : todo
-      )
+        todo.id === id ? { ...todo, checked: !todo.checked } : todo,
+      ),
     );
-  };
+  }, []);
 
   return { todos, addTodo, removeTodo, toggleTodoChecked };
 }

--- a/src/hooks/useTodos.jsx
+++ b/src/hooks/useTodos.jsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 function createBulkTodos() {
   const array = [];
-  for (let i = 1; i < 2500; i++) {
+  for (let i = 1; i < 10000; i++) {
     array.push({
       id: i,
       text: `할 일${i}`,


### PR DESCRIPTION
안녕하세요, 혜령 리뷰어님! 벌써 마지막 미션 리뷰로 찾아 뵙습니다!
이번 미션은 Step 1에서 말씀드린 최적화를 적용한 미션입니다.
마지막까지 코드 리뷰해주셔서 감사합니다!

## 🧐 성능 병목 현상 분석 
<img width="1235" height="451" alt="Pre-Optimization" src="https://github.com/user-attachments/assets/89f813ab-a320-4fb5-8c4c-af5c87089416" />


- **측정 지표:** Todo 아이템 2,500개 기준, 초기 렌더링 및 추가 시 약 **700ms** 소요.
- **원인:** 
    - 새로운 Todo가 추가될 때마다 리스트 전체 컴포넌트가 불필요하게 리렌더링 되는 현상 발생하는 것입니다.
    - 특정 Todo의 체크 나 삭제 시에도 변화가 없는 나머지 2,499개의 컴포넌트가 다시 계산되면서 성능이 떨어진다고 판단.
    - 수천 개의 DOM 노드를 한꺼번에 렌더링하면서 브라우저의 연산 부담 증가.

## 💡 최적화 적용 방법

1. **React.memo & useCallback**
    - `React.memo`를 사용하여 props가 변경되지 않은 Todo 아이템의 불필요한 리렌더링을 방지했습니다.
    - 함수형 props 전달 시 참조 무결성을 유지하기 위해 `useCallback`을 적용했습니다.

2. **react-virtualized**
    - 컴포넌트 메모이제이션만으로는 2,500개의 실제 DOM 노드를 관리하는 데 한계가 있어, Windowing 기법을 도입했습니다. 실제로 virtualized를 사용 안했을때 결과가 오히려 느려지는 것을 볼 수 있었습니다. (900ms)
    - `react-virtualized`를 통해 현재 Viewport에 보이는 부분만 렌더링하도록 개선했습니다 (900ms -> 14ms).
    - `overscanRowCount={5}` 설정을 통해 스크롤 시 발생할 수 있는 깜빡임 현상을 최소화하고 사용자 경험을 개선했습니다.
   
    -  ### react-virtualized 사용전
         <img width="873" height="424" alt="Screenshot 2026-01-23 210457" src="https://github.com/user-attachments/assets/e220f484-6391-4a13-bdbe-d255ed498a9e" />

    - ### react-virtualized 사용 후
         <img width="1272" height="399" alt="Screenshot 2026-01-23 190728" src="https://github.com/user-attachments/assets/e7b5df02-96bf-4e43-beff-e33abccb62a8" />

## ✏️ 고민했던 점 & 리뷰 요청사항
TodoListItem의 `handleToggle`, `handleRemove`같은 경우 useCallback을 사용할지 고민했습니다. TodoList와 TodoListItem이 이미 memo가 되어 있고, props의 reference가 바뀌지 않을 것으로 판단해서 사용하지 않기로 했습니다.

TodoInsert는 컴포넌트가 간단해서 React.memo를 사용하지 않기로 결정했습니다.

### 리뷰 요청 사항
   코드의 최적화가 잘 되었는지, 또한 제가 놓친 부분이 있는지 피드백 주시면 감사하겠습니다!

# 🎥 실행영상

https://github.com/user-attachments/assets/99bb733e-1e5f-4a6d-845f-16775067ca57



